### PR TITLE
change actions/setup-python from v1 to v2

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.7.6'
         architecture: 'x64'


### PR DESCRIPTION
## Background

https://github.com/covid-projections/covid-data-public/actions?query=workflow%3A%22Update+source+data%22 is broken.

* https://trello.com/c/9mi1AA9y/121-covid-data-public-update-source-data-github-action-failing
* https://covidactnow.slack.com/archives/C0110QQAPJA/p1589322334246900

This PR does not add slack notification because I couldn't quickly work out how to get  `secret.SLACK_WEBHOOK` setup.

## Tested

This is a subset of the branch run in https://github.com/covid-projections/covid-data-public/runs/668872392 and it seemed to work there.
